### PR TITLE
Use lean istio distribution

### DIFF
--- a/cnab/app/kab/manifest.yaml
+++ b/cnab/app/kab/manifest.yaml
@@ -6,15 +6,7 @@ metadata:
 spec:
   resources:
   - name: istio
-    namespace: istio-system
-    path: https://storage.googleapis.com/projectriff/istio/istio-v1.0.7-riff.yaml
-    checks:
-    - kind: Pod
-      selector:
-        matchLabels:
-          istio: sidecar-injector
-      jsonpath: .status.phase
-      pattern: Running
+    path: https://storage.googleapis.com/projectriff/istio/istio-v1.0.7-lean-riff.yaml
   - name: knative-build
     path: https://storage.googleapis.com/knative-releases/build/previous/v0.6.0/build.yaml
   - name: knative-serving


### PR DESCRIPTION
The lean istio distribution uses Istio for ingress, but does not inject
sidecars. This means the mesh is opt-in on a component by component
basis rather than being assumed.

Skipping the sidecar will dramatically improve pod startup time as there
is no init container or 5+ second window after the main container starts
waiting for iptable rules to settle.