### PR TITLE
fix parameter destination

### DIFF
--- a/duffle.json
+++ b/duffle.json
@@ -28,7 +28,7 @@
                 "description": "absolute path to the manifest file"
             },
             "destination": {
-                "env:": "MANIFEST_FILE"
+                "env": "MANIFEST_FILE"
             },
             "default": "/cnab/app/kab/manifest.yaml"
         },
@@ -38,7 +38,7 @@
                 "description": "one of logrus log level values"
             },
             "destination": {
-                "env:": "LOG_LEVEL"
+                "env": "LOG_LEVEL"
             },
             "default": "info"
         },


### PR DESCRIPTION
With this fix, the parameters (specified on the command line OR in the parameters file) will now be set as environment variables inside the invocation container.